### PR TITLE
Fix server error on user's profile page

### DIFF
--- a/resources/views/profiles/activities/created_favorite.blade.php
+++ b/resources/views/profiles/activities/created_favorite.blade.php
@@ -1,9 +1,16 @@
 @component('profiles.activities.activity')
     @slot('heading')
-        {{ $profile->name }} a aimé <a href="{{ $activity->subject->favoritable->path() }}">un post</a>.
+        {{ $profile->name }} a aimé
+        @if(is_null($activity->subject))
+            un post qui n'existe plus.
+        @else
+            <a href="{{ $activity->subject->favoritable->path() }}">un post</a>.
+        @endif
     @endslot
 
-    @slot('body')
-        {{ $activity->subject->favoritable->body }}
-    @endslot
+    @unless(is_null($activity->subject))
+        @slot('body')
+            {{ $activity->subject->favoritable->body }}
+        @endslot
+    @endunless
 @endcomponent


### PR DESCRIPTION
# Unexpected behavior
When visiting a user's profile, the browser displays a 500 error code.
Logs indicate this issue arises when the user has favorited a post which no longer exists:
```
[2024-10-30 10:11:44] production.ERROR: Attempt to read property "favoritable" on null (View: /home/forge/members.agepac.org/resources/views/profiles/activities/created_favorite.blade.php)
```

# Expected behavior
The page loads properly

# What this PR does
This PR introduces edge case handling enabling an activity referring to a deleted post to still be displayed.
<img width="678" alt="Screenshot 2024-10-30 at 11 54 56" src="https://github.com/user-attachments/assets/e479d4d0-e7b5-45f5-9d59-3b879889f919">
